### PR TITLE
Building on Ubuntu and removing warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 *.i*86
 *.x86_64
 *.hex
+pem2mincrypt

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXE = pem2mincrypt
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 $(EXE): $(OBJ)
-	gcc $(LDFLAGS) -o $(EXE) $(OBJ)
+	gcc -o $(EXE) $(OBJ) $(LDFLAGS)
 
 .PHONY: clean
 

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ $(EXE): $(OBJ)
 .PHONY: clean
 
 clean: 
-	rm $(OBJ) $(EXE)
+	rm -f $(OBJ) $(EXE)
 


### PR DESCRIPTION
Reordering the linker call on Makefile, so it would build on Ubuntu (tested on Ubuntu 14 / gcc 4.8.4);

adding a "-f" to remove warning when doing "make clean" on a clean directory;

adding the output object to .gitignore
